### PR TITLE
Use config value over default if not in env

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -277,13 +277,17 @@ func readEnvVars(cfg interface{}, update bool) error {
 			continue
 		}
 
-		rawValue := meta.defValue
+		var rawValue *string
 
 		for _, env := range meta.envList {
 			if value, ok := os.LookupEnv(env); ok {
 				rawValue = &value
 				break
 			}
+		}
+
+		if rawValue == nil && meta.fieldValue.IsZero() {
+			rawValue = meta.defValue
 		}
 
 		if rawValue == nil {

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -855,6 +855,7 @@ func TestReadConfig(t *testing.T) {
 		Number    int64  `yaml:"number" env:"TEST_NUMBER" env-default:"1"`
 		String    string `yaml:"string" env:"TEST_STRING" env-default:"default"`
 		NoDefault string `yaml:"no-default" env:"TEST_NO_DEFAULT"`
+		NoEnv     string `yaml:"no-env" env-default:"default"`
 	}
 
 	tests := []struct {
@@ -871,13 +872,15 @@ func TestReadConfig(t *testing.T) {
 number: 2
 string: test
 no-default: NoDefault
+no-env: this
 `,
 			ext: "yaml",
 			env: nil,
 			want: &config{
-				Number:    1,
-				String:    "default",
+				Number:    2,
+				String:    "test",
 				NoDefault: "NoDefault",
+				NoEnv:     "this",
 			},
 			wantErr: false,
 		},
@@ -894,6 +897,29 @@ no-default: NoDefault
 				Number:    2,
 				String:    "test",
 				NoDefault: "",
+				NoEnv:     "default",
+			},
+			wantErr: false,
+		},
+
+		{
+			name: "yaml_and_env",
+			file: `
+number: 2
+string: test
+no-default: NoDefault
+no-env: this
+`,
+			ext: "yaml",
+			env: map[string]string{
+				"TEST_NUMBER": "3",
+				"TEST_STRING": "fromEnv",
+			},
+			want: &config{
+				Number:    3,
+				String:    "fromEnv",
+				NoDefault: "NoDefault",
+				NoEnv:     "this",
 			},
 			wantErr: false,
 		},
@@ -907,6 +933,7 @@ no-default: NoDefault
 				Number:    1,
 				String:    "default",
 				NoDefault: "",
+				NoEnv:     "default",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
This is a proposed fix for https://github.com/ilyakaznacheev/cleanenv/issues/40.

This behaves the way I expected, given this line of the documentation:
> 3. if no value was found on the first two steps, the field will be filled with the default value (env-default tag) if it is set.

in https://github.com/ilyakaznacheev/cleanenv#read-configuration.

I'm no reflect wizard, so I suggest a careful review.  It works in my testing though.