### PR TITLE
Update library used for toml support

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -13,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/joho/godotenv"
+	"github.com/pelletier/go-toml"
 	"gopkg.in/yaml.v2"
 	"olympos.io/encoding/edn"
 )
@@ -156,7 +157,11 @@ func parseJSON(r io.Reader, str interface{}) error {
 
 // parseTOML parses TOML from reader to data structure
 func parseTOML(r io.Reader, str interface{}) error {
-	_, err := toml.DecodeReader(r, str)
+	bytes, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	err = toml.Unmarshal(bytes, str)
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ilyakaznacheev/cleanenv
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/joho/godotenv v1.3.0
+	github.com/pelletier/go-toml v1.8.1
 	gopkg.in/yaml.v2 v2.2.2
 	olympos.io/encoding/edn v0.0.0-20200308123125-93e3b8dd0e24
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
The currently used toml library (github.com/BurntSushi/toml) has officially been marked as unmaintained by its owner. As such, it might be wise to move to a new library (support for newer versions of the TOML spec as burntsushi/toml only supports v0.4.0, bug/security fixes, etc).