### PR TITLE
Add functions for prefixed environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,30 @@ if err != nil {
 }
 ```
 
+### Read Environment Variables with Common Prefix
+
+Some applications are configured with environment variables that share the same prefix. Prefixed
+environment variables such as `APPNAME_PORT, APPNAME_HOST, ...` can be read without repeating the
+prefix in struct tags:
+```go
+import github.com/ilyakaznacheev/cleanenv
+
+type ConfigDatabase struct {
+    Port     string `env:"PORT" env-default:"5432"`
+    Host     string `env:"HOST" env-default:"localhost"`
+    Name     string `env:"NAME" env-default:"postgres"`
+    User     string `env:"USER" env-default:"user"`
+    Password string `env:"PASSWORD"`
+}
+
+var cfg ConfigDatabase
+
+err := cleanenv.ReadEnvWithPrefix("appname", &cfg)
+if err != nil {
+    ...
+}
+```
+
 ### Update Environment Variables
 
 Some environment variables may change during the application run. To get the new values you need to mark these variables as updatable with the tag `env-upd` and then run the update function:


### PR DESCRIPTION
Thanks so much for this repo, I've found it extremely useful!

This PR adds functionality for easily working with environment variables that share a common prefix, as is often the case for the configuration of an application.  For example, consider (modified from the README in the current master branch):
```go
type ConfigDatabase struct {
    Port     string `env:"PORT" env-default:"5432"`
    Host     string `env:"HOST" env-default:"localhost"`
    Name     string `env:"NAME" env-default:"postgres"`
    User     string `env:"USER" env-default:"user"`
    Password string `env:"PASSWORD"`
}
```
The environment variables serving as the configuration for the database application might share a common prefix such as `DB` or `APPNAME` (e.g., `DB_PORT`, `DB_HOST`, etc).  To cleanly and easily handle this case, rather than repeating the prefix in the struct tags (hindering readability), we add the functions:
- `func ReadConfigWithPrefix(path string, prefix string, cfg interface{}) error`
- `func ReadEnvWithPrefix(prefix string, cfg interface{}) error`
- `func UpdateEnvWithPrefix(prefix string, cfg interface{}) error`

so that the prefix is specified once on read.  Following the example above, we read the prefixed environment variables as:
```go
var cfg ConfigDatabase

err := cleanenv.ReadEnvWithPrefix("appname", &cfg)
if err != nil {
    ...
}
```

For completeness, this PR also adds the following description function:
- `func GetDescriptionWithPrefix(cfg interface{}, prefix string, headerText *string) (string, error)`

This functionality is intended to work similar to the prefix functionality of [kelseyhightower/envconfig](https://github.com/kelseyhightower/envconfig)

Thanks for considering this PR, and I'm more than happy to iterate on any feedback you might have.