### PR TITLE
Add support for prefixing fields of nested structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Library uses tags to configure the model of configuration structure. There are t
 - `env-separator="<value>"` - custom list and map separator. If not set, the default separator `,` will be used;
 - `env-description="<value>"` - environment variable description;
 - `env-layout="<value>"` - parsing layout (for types like `time.Time`);
+- `env-prefix="<value>"` - prefix for all fields of nested structure (only for nested structures);
 
 ## Supported types
 

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -366,6 +366,66 @@ func TestReadEnvVarsTime(t *testing.T) {
 	}
 }
 
+func TestReadEnvVarsWithPrefix(t *testing.T) {
+	type Logging struct {
+		Debug bool `env:"DEBUG"`
+	}
+
+	type DBConfig struct {
+		Host    string  `env:"DB_HOST"`
+		Port    int     `env:"DB_PORT"`
+		Logging Logging `env-prefix:"DB_"`
+	}
+
+	type Config struct {
+		Default  DBConfig
+		ReadOnly DBConfig `env-prefix:"READONLY_"`
+		Extra    DBConfig `env-prefix:"EXTRA_"`
+	}
+
+	var env = map[string]string{
+		"DB_HOST":           "db1.host",
+		"DB_PORT":           "10000",
+		"DB_DEBUG":          "true",
+		"READONLY_DB_HOST":  "db2.host",
+		"READONLY_DB_PORT":  "20000",
+		"READONLY_DB_DEBUG": "true",
+		"EXTRA_DB_HOST":     "db3.host",
+		"EXTRA_DB_PORT":     "30000",
+		"EXTRA_DB_DEBUG":    "true",
+	}
+	for k, v := range env {
+		os.Setenv(k, v)
+	}
+
+	var cfg Config
+	if err := readEnvVars(&cfg, false); err != nil {
+		t.Fatal("failed to read env vars", err)
+	}
+
+	var expected = Config{
+		Default: DBConfig{
+			Host:    "db1.host",
+			Port:    10000,
+			Logging: Logging{Debug: true},
+		},
+		ReadOnly: DBConfig{
+			Host:    "db2.host",
+			Port:    20000,
+			Logging: Logging{Debug: true},
+		},
+		Extra: DBConfig{
+			Host:    "db3.host",
+			Port:    30000,
+			Logging: Logging{Debug: true},
+		},
+	}
+
+	if !reflect.DeepEqual(cfg, expected) {
+		t.Errorf("wrong data %v, want %v", cfg, expected)
+	}
+}
+
 type testConfigUpdateFunction struct {
 	One   string
 	Two   string


### PR DESCRIPTION
This PR adds support for prefixing fields of nested structures. Can be very useful in situations when nested structures need to be reused and environment variables names should be different (prefixed).  

Example:
```
	type Logging struct {
		Debug bool `env:"DEBUG"`
	}

	type DBConfig struct {
		Host    string  `env:"DB_HOST"`
		Port    int     `env:"DB_PORT"`
		Logging Logging `env-prefix:"DB_"`
	}

	type Config struct {
		Default  DBConfig
		ReadOnly DBConfig `env-prefix:"READONLY_"`
		Extra    DBConfig `env-prefix:"EXTRA_"`
	}

```

After calling `ReadEnv()` on `Config` structure, following env variables names will be parsed:

```
DB_HOST
DB_PORT
DB_DEBUG
READONLY_DB_HOST
READONLY_DB_PORT
READONLY_DB_DEBUG
EXTRA_DB_HOST
EXTRA_DB_PORT
EXTRA_DB_DEBUG
```

I hope this feature will be useful.

And thanks for this package.
