### PR TITLE
Make reading a config file optional

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -87,7 +87,7 @@ type Updater interface {
 //	 }
 func ReadConfig(path string, cfg interface{}) error {
 	err := parseFile(path, cfg)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "EOF") && !strings.Contains(err.Error(), "no such file or directory") {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ilyakaznacheev/cleanenv
+module github.com/outOfBoun/cleanenv
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
For my usecase, I consider that a config file should be optional and should just skip to parsing env vars. Maybe this should be configurable and not directly forced as I just did.