### PR TITLE
Skip empty value assignment

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -321,7 +321,9 @@ func readEnvVars(cfg interface{}, update bool) error {
 
 		for _, env := range meta.envList {
 			if value, ok := os.LookupEnv(env); ok {
-				rawValue = &value
+				if len(strings.TrimSpace(value)) > 0 {
+					rawValue = &value
+				}
 				break
 			}
 		}


### PR DESCRIPTION
There might be a situation when a shell contains an empty environment variable. In such a case, we get the next error for a boolean field, for example:
```
strconv.ParseBool: parsing "": invalid syntax
```

I propose to treat empty string values as absent ones.
