### PR TITLE
Read From Environment Variable Even If Parse File Failed

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -93,9 +93,9 @@ func ReadConfig(path string, cfg interface{}) error {
 		if err != nil {
 			return fmt.Errorf("%s: %w", envErr.Error(), err)
 		}
-		return envErr
 	}
-	return err
+
+	return nil
 }
 
 // ReadEnv reads environment variables into the structure.

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -68,7 +68,7 @@ type Updater interface {
 }
 
 // ReadConfig reads configuration file and parses it depending on tags in structure provided.
-// Then it reads and parses
+// Then it reads and parses configuration from environment variable
 //
 // Example:
 //
@@ -88,11 +88,14 @@ type Updater interface {
 //	 }
 func ReadConfig(path string, cfg interface{}) error {
 	err := parseFile(path, cfg)
-	if err != nil {
-		return err
-	}
 
-	return readEnvVars(cfg, false)
+	if envErr := readEnvVars(cfg, false); envErr != nil {
+		if err != nil {
+			return fmt.Errorf("%s: %w", envErr.Error(), err)
+		}
+		return envErr
+	}
+	return err
 }
 
 // ReadEnv reads environment variables into the structure.

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -87,6 +87,8 @@ type Updater interface {
 //	     ...
 //	 }
 func ReadConfig(path string, cfg interface{}) error {
+	readDefaults(cfg)
+
 	err := parseFile(path, cfg)
 
 	if envErr := readEnvVars(cfg, false); envErr != nil {
@@ -329,6 +331,29 @@ func readStructMetadata(cfgRoot interface{}) ([]structMeta, error) {
 	}
 
 	return metas, nil
+}
+
+// readDefaults reads default values to the provided configuration structure
+//
+// Note: this method will overwrite existing values in the configuration structure
+func readDefaults(cfg interface{}) error {
+	metaInfo, err := readStructMetadata(cfg)
+	if err != nil {
+		return err
+	}
+
+	for _, meta := range metaInfo {
+		rawValue := meta.defValue
+		if rawValue == nil {
+			continue
+		}
+
+		if err := parseValue(meta.fieldValue, *rawValue, meta.separator, meta.layout); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // readEnvVars reads environment variables to the provided configuration structure

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -1119,19 +1119,68 @@ no-env: this
 		},
 
 		{
-			name:    "unknown",
-			file:    "-",
-			ext:     "",
+			name: "unknown filetype fallback to env",
+			file: "-",
+			ext:  "",
+			env: map[string]string{
+				"TEST_NUMBER": "3",
+				"TEST_STRING": "fromEnv",
+			},
+			want: &config{
+				Number:    3,
+				String:    "fromEnv",
+				NoDefault: "",
+				NoEnv:     "default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "parsing error fallback to env",
+			file: "-",
+			ext:  "json",
+			env: map[string]string{
+				"TEST_NUMBER": "3",
+				"TEST_STRING": "fromEnv",
+			},
+			want: &config{
+				Number:    3,
+				String:    "fromEnv",
+				NoDefault: "",
+				NoEnv:     "default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "file and env parse error",
+			file: "-",
+			ext:  "json",
+			env: map[string]string{
+				"TEST_NUMBER": "five hundred",
+				"TEST_STRING": "fromEnv",
+			},
 			want:    nil,
 			wantErr: true,
 		},
-
 		{
-			name:    "parsing error",
-			file:    "-",
-			ext:     "json",
-			want:    nil,
-			wantErr: true,
+			name: "parsed file and failed to parse env",
+			file: `
+number: 2
+string: test
+no-default: NoDefault
+no-env: this
+`,
+			ext: "yaml",
+			env: map[string]string{
+				"TEST_NUMBER": "five hundred",
+				"TEST_STRING": "fromEnv",
+			},
+			want: &config{
+				Number:    2,
+				String:    "test",
+				NoDefault: "NoDefault",
+				NoEnv:     "this",
+			},
+			wantErr: false,
 		},
 	}
 

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -1167,7 +1167,6 @@ no-env: this
 number: 2
 string: test
 no-default: NoDefault
-no-env: this
 `,
 			ext: "yaml",
 			env: map[string]string{
@@ -1178,7 +1177,7 @@ no-env: this
 				Number:    2,
 				String:    "test",
 				NoDefault: "NoDefault",
-				NoEnv:     "this",
+				NoEnv:     "default",
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
## Related Issue

https://github.com/ilyakaznacheev/cleanenv/issues/79

## Motivation and Context

<details>
  <summary>Full Snippet of Read Configuration section of README</summary>
  
> You can read a configuration file and environment variables in a single function call.
> ```go
> import "github.com/ilyakaznacheev/cleanenv"
> 
> type ConfigDatabase struct {
>     Port     string `yaml:"port" env:"PORT" env-default:"5432"`
>     Host     string `yaml:"host" env:"HOST" env-default:"localhost"`
>     Name     string `yaml:"name" env:"NAME" env-default:"postgres"`
>     User     string `yaml:"user" env:"USER" env-default:"user"`
>     Password string `yaml:"password" env:"PASSWORD"`
> }
> 
> var cfg ConfigDatabase
> 
> err := cleanenv.ReadConfig("config.yml", &cfg)
> if err != nil {
>     ...
> }
> ```
> 
> This will do the following:
> 
> 1. parse configuration file according to YAML format (`yaml` tag in this case);
> 1. reads environment variables and overwrites values from the file with the values which was found in the environment (`env` tag);
> 1. if no value was found on the first two steps, the field will be filled with the default value (`env-default` tag) if it is set.
</details>

Current behavior of `ReadConfig` is that it will return an error if it failed to read configuration from file and the method will not attempt to read configuration from environment variables. Thus, this statement from Read Configuration section of README is not necessarily true:

> reads environment variables and overwrites values from the file with the values which was found in the environment (`env` tag);

Because `parseFile` does not fill the config struct with default values and `readEnvVars` is the method that will fill the config struct with default values, once `parseFile` returns an error `ReadConfig` will not execute `readEnvVars`. Which causes the current behavior of `ReadConfig` invalidating this statement:

> if no value was found on the first two steps, the field will be filled with the default value (`env-default` tag) if it is set.

To address the discrepancy, we decided to open this PR to update `ReadConfig` so that the method:
- Will continue to attempt to read configuration from environment variables even if it failed to read configuration from file
- Only returns an error if it can't read configuration from both file and environment variable
- Fill config struct with default values even if `parseFile` or `readEnvVars` returns an error

## How Has This Been Tested?

All preexisting tests passed except `unknown` subtest and `parsing error` subtest for `TestReadConfig` due to the behavior change we implemented for `ReadConfig`. Thus we modified  `unknown` and `parsing error` to become `unknown filetype fallback to env` and `parsing error fallback to env` respectively. So that instead of testing to ensure `ReadConfig` returns an error if it failed to parse file, the updated test cases testing to ensure `ReadConfig` will run `readEnvVars` if it failed to parse file.

Two new subtests were added to `TestReadConfig`. The first one, called `file and env parse error`, was added to cover the case where neither the file or environment variables could be successfully read. The second one, called `parsed file and failed to parse env`, was added to cover the case where `ReadConfig` is able to read from file but not able to read from environment variables.

Since `readDefaults` method was added to prepopulate the config struct with default values, new test called `TestReadDefaults`, with two subtests, was added to ensure the method is properly tested.

Besides `ReadConfig` and the newly created `readDefaults`, functionalities of other methods were not modified. Thus, changes implemented in this PR should not affect other areas of this library. 

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.