### PR TITLE
added basic context to the error message on what went wrong

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -444,7 +444,7 @@ func readEnvVars(cfg interface{}, update bool) error {
 		}
 
 		if err := parseValue(meta.fieldValue, *rawValue, meta.separator, meta.layout); err != nil {
-			return fmt.Errorf("field %v env %v: %v", meta.fieldName, envName, err)
+			return fmt.Errorf("parsing field %v env %v: %v", meta.fieldName, envName, err)
 		}
 	}
 

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -438,8 +438,13 @@ func readEnvVars(cfg interface{}, update bool) error {
 			continue
 		}
 
+		var envName string
+		if len(meta.envList) > 0 {
+			envName = meta.envList[0]
+		}
+
 		if err := parseValue(meta.fieldValue, *rawValue, meta.separator, meta.layout); err != nil {
-			return err
+			return fmt.Errorf("field %v env %v: %v", meta.fieldName, envName, err)
 		}
 	}
 


### PR DESCRIPTION
i saw some request about adding context to the error since error like parse.bool gives me none. pls check it