### PR TITLE
Refactor error messages for missing variables, on parsing stage.

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -426,7 +426,7 @@ func (e readEnvVarsError) Error() string {
 			tmp += "\n"
 		}
 	}
-	parsingErrs := fmt.Sprintf("parsing errors for enviorment variables: \n%s", tmp)
+	parsingErrs := fmt.Sprintf("parsing errors for environment variables: \n%s", tmp)
 
 	var res string
 

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -449,6 +449,9 @@ func readEnvVars(cfg interface{}, update bool) error {
 		return err
 	}
 
+	// store initial configuration, so we can return default values if errors occur
+	initialCfg := reflect.ValueOf(cfg).Elem().Interface()
+
 	if updater, ok := cfg.(Updater); ok {
 		if err := updater.Update(); err != nil {
 			return err
@@ -499,6 +502,8 @@ func readEnvVars(cfg interface{}, update bool) error {
 	}
 
 	if !errs.IsEmpty() {
+		// restore initial configuration
+		reflect.ValueOf(cfg).Elem().Set(reflect.ValueOf(initialCfg))
 		return errs
 	}
 


### PR DESCRIPTION
Before we would return error right aways. Now when we encounter an error on parsing stage, we try to list all the missing or incorrect envs. This should make debugging for our users easier.

Also added some tests for new errors.

Here is an example of new error message.

```
missing required environment variables: 
	"PORT"
	"JWT_SALT"
	"READ_TIMEOUT"
parsing errors for environment variables: 
	field WriteTimeout env "WRITE_TIMEOUT": time: invalid duration "incorrect"
```