### PR TITLE
Support encoding.TextUnmarshaler

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -1,6 +1,7 @@
 package cleanenv
 
 import (
+	"encoding"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -545,6 +546,14 @@ func parseValue(field reflect.Value, value, sep string, layout *string) error {
 		// look for supported struct parser
 		if structParser, found := validStructs[valueType]; found {
 			return structParser(&field, value, layout)
+		}
+
+		if field.CanInterface() {
+			if cs, ok := field.Interface().(encoding.TextUnmarshaler); ok {
+				return cs.UnmarshalText([]byte(value))
+			} else if csp, ok := field.Addr().Interface().(encoding.TextUnmarshaler); ok {
+				return csp.UnmarshalText([]byte(value))
+			}
 		}
 
 		return fmt.Errorf("unsupported type %s.%s", valueType.PkgPath(), valueType.Name())


### PR DESCRIPTION
Many struct types in third-party libraries support `encoding.TextUnmarshaler` interface to fill the value by itself. (eg. https://github.com/shopspring/decimal/blob/f55dd564545cec84cf84f7a53fb3025cdbec1c4f/decimal.go#L1429)

 And yaml parser will unmarshal it. https://github.com/go-yaml/yaml/blob/00bbc0947ae889b9e480044dbc3bc3e3216a6a89/decode.go#L591-L609

`Setter` interface is not perfect because `Setter` is a custom interface we have to wrap the third-party type.

How about trying encoding.TextUnmarshaler if we cannot find a proper unmarshal way?