### PR TITLE
[#86] Published methods for get configuration through io.Reader

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -153,17 +153,17 @@ func parseFile(path string, cfg interface{}) error {
 	return nil
 }
 
-// parseYAML parses YAML from reader to data structure
+// ParseYAML parses YAML from reader to data structure
 func ParseYAML(r io.Reader, str interface{}) error {
 	return yaml.NewDecoder(r).Decode(str)
 }
 
-// parseJSON parses JSON from reader to data structure
+// ParseJSON parses JSON from reader to data structure
 func ParseJSON(r io.Reader, str interface{}) error {
 	return json.NewDecoder(r).Decode(str)
 }
 
-// parseTOML parses TOML from reader to data structure
+// ParseTOML parses TOML from reader to data structure
 func ParseTOML(r io.Reader, str interface{}) error {
 	_, err := toml.NewDecoder(r).Decode(str)
 	return err

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -135,11 +135,11 @@ func parseFile(path string, cfg interface{}) error {
 	// parse the file depending on the file type
 	switch ext := strings.ToLower(filepath.Ext(path)); ext {
 	case ".yaml", ".yml":
-		err = parseYAML(f, cfg)
+		err = ParseYAML(f, cfg)
 	case ".json":
-		err = parseJSON(f, cfg)
+		err = ParseJSON(f, cfg)
 	case ".toml":
-		err = parseTOML(f, cfg)
+		err = ParseTOML(f, cfg)
 	case ".edn":
 		err = parseEDN(f, cfg)
 	case ".env":
@@ -154,17 +154,17 @@ func parseFile(path string, cfg interface{}) error {
 }
 
 // parseYAML parses YAML from reader to data structure
-func parseYAML(r io.Reader, str interface{}) error {
+func ParseYAML(r io.Reader, str interface{}) error {
 	return yaml.NewDecoder(r).Decode(str)
 }
 
 // parseJSON parses JSON from reader to data structure
-func parseJSON(r io.Reader, str interface{}) error {
+func ParseJSON(r io.Reader, str interface{}) error {
 	return json.NewDecoder(r).Decode(str)
 }
 
 // parseTOML parses TOML from reader to data structure
-func parseTOML(r io.Reader, str interface{}) error {
+func ParseTOML(r io.Reader, str interface{}) error {
 	_, err := toml.NewDecoder(r).Decode(str)
 	return err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ilyakaznacheev/cleanenv
 
 require (
-	github.com/BurntSushi/toml v1.1.0
-	github.com/joho/godotenv v1.4.0
+	github.com/BurntSushi/toml v1.2.1
+	github.com/joho/godotenv v1.5.1
 	gopkg.in/yaml.v3 v3.0.1
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
-github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
-github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Fix issue #86. Published methods for get configuration in based formats through io.Reader for user choise location of configuration file (local storage, http, i.e.)

Update packages toml and godotenv