### PR TITLE
Required description

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -588,8 +588,11 @@ func GetDescription(cfg interface{}, headerText *string) (string, error) {
 		}
 
 		for idx, env := range m.envList {
-
-			elemDescription := fmt.Sprintf("\n  %s %s", env, m.fieldValue.Kind())
+			var required string
+			if m.required && idx == 0 {
+				required = "* "
+			}
+			elemDescription := fmt.Sprintf("\n  %s%s %s", required, env, m.fieldValue.Kind())
 			if idx > 0 {
 				elemDescription += fmt.Sprintf(" (alternative to %s)", m.envList[0])
 			}

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -588,7 +588,7 @@ func GetDescription(cfg interface{}, headerText *string) (string, error) {
 		}
 
 		for idx, env := range m.envList {
-			var required string
+			required := "  "
 			if m.required && idx == 0 {
 				required = "* "
 			}

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -590,9 +590,9 @@ func GetDescription(cfg interface{}, headerText *string) (string, error) {
 		for idx, env := range m.envList {
 			required := "  "
 			if m.required && idx == 0 {
-				required = "* "
+				required = " *"
 			}
-			elemDescription := fmt.Sprintf("\n  %s%s %s", required, env, m.fieldValue.Kind())
+			elemDescription := fmt.Sprintf("\n%s%s %s", required, env, m.fieldValue.Kind())
 			if idx > 0 {
 				elemDescription += fmt.Sprintf(" (alternative to %s)", m.envList[0])
 			}

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -805,6 +805,11 @@ func TestGetDescription(t *testing.T) {
 		Three int
 	}
 
+	type testRequired struct {
+		Required string `env:"REQUIRED" env-required:"true" env-description:"a required field"`
+		Optional string `env:"OPTIONAL" env-description:"an optional field"`
+	}
+
 	header := "test header:"
 
 	tests := []struct {
@@ -876,7 +881,15 @@ func TestGetDescription(t *testing.T) {
 				"\n  TWO int\n    \ttwo",
 			wantErr: false,
 		},
-
+		{
+			name:   "required",
+			cfg:    &testRequired{},
+			header: nil,
+			want: "Environment variables:" +
+				"\n  OPTIONAL string\n    \tan optional field" +
+				"\n *REQUIRED string\n    \ta required field",
+			wantErr: false,
+		},
 		{
 			name:    "error",
 			cfg:     123,


### PR DESCRIPTION
Update the output of `GetDescription` to include an asterisk before required variables.