### PR TITLE
print the name of the env var when a required var is missing

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -429,9 +429,18 @@ func readEnvVars(cfg interface{}, update bool) error {
 		}
 
 		if rawValue == nil && meta.required && meta.isFieldValueZero() {
+			if len(meta.envList) == 0 {
+				return fmt.Errorf("env list for field %q is empty but is set as required", meta.fieldName)
+			}
+			if len(meta.envList) == 1 {
+				return fmt.Errorf(
+					"environment variable %q is required but the value is not provided",
+					meta.envList[0],
+				)
+			}
 			return fmt.Errorf(
-				"field %q is required but the value is not provided",
-				meta.fieldName,
+				"environment variable %q (aliases=%v) is required but the value is not provided",
+				meta.envList[0], meta.envList[1:],
 			)
 		}
 


### PR DESCRIPTION
Previously, when a required variable is not set, the error message only contained the struct field name but not the name of the associated environment variable. This PR changes the error message to include the env var names as required so it is easier to see what needs to be set from the user perspective.