### PR TITLE
.env.* support and possible to check require field after all config loading

### DIFF
--- a/example/parse_multiple_files/.env.local
+++ b/example/parse_multiple_files/.env.local
@@ -1,0 +1,2 @@
+DB_PORT=5435
+DB_PASSWORD=password

--- a/example/parse_multiple_files/README.md
+++ b/example/parse_multiple_files/README.md
@@ -1,5 +1,5 @@
 # Parse multiple files for configuration
 
-This example shows how the package can be used to read from mutiple configuration files and assign them to the same structure.
+This example shows how the package can be used to read from multiple configuration files and assign them to the same structure.
 
 In this example, the configuration is read from ```db_config.yaml```,```email_config.yaml``` and ```general_config.yaml``` and the values are stored in the ```config``` struct.

--- a/example/parse_multiple_files/db_config.yaml
+++ b/example/parse_multiple_files/db_config.yaml
@@ -1,7 +1,6 @@
 database:
   host: "localhost"
   user: "root"
-  password: "password"
   name: "cleanenv"
   port: "5432"
   ssl_mode: "disable"

--- a/example/parse_multiple_files/main.go
+++ b/example/parse_multiple_files/main.go
@@ -15,10 +15,10 @@ type config struct {
 
 type databaseConfig struct {
 	User     string `yaml:"user"`
-	Password string `yaml:"password"`
+	Password string `env-required:"true" yaml:"password" env:"DB_PASSWORD"`
 	Name     string `yaml:"name"`
 	Host     string `yaml:"host"`
-	Port     string `yaml:"port"`
+	Port     string `yaml:"port" env:"DB_PORT"`
 	SSLMode  string `yaml:"ssl_mode"`
 }
 
@@ -28,7 +28,7 @@ type emailService struct {
 }
 
 func main() {
-	cfg, err := ParseConfigFiles("./db_config.yaml", "./email_config.yaml", "./general_config.yaml")
+	cfg, err := ParseConfigFiles("./db_config.yaml", "./email_config.yaml", "./general_config.yaml", "./.env.local")
 	if err != nil {
 		log.Printf("Error parsing config files: %v", err)
 		return


### PR DESCRIPTION
1. support files like .env.local, .env.dev etc...
But I don't recommend use it if it possible. The better solution is config.yml for base configs and .env in .gitignore for environment changes
2. you can disable check required fields during loading part of config and enable it again on read last file. See example

sorry for no tests, i hope somebody help me with that