### PR TITLE
Using error struct for additionals data

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -249,7 +249,7 @@ type structMeta struct {
 	description string
 	updatable   bool
 	required    bool
-	path        []string
+	path        string
 }
 
 // isFieldValueZero determines if fieldValue empty or not
@@ -303,10 +303,10 @@ func readStructMetadata(cfgRoot interface{}) ([]structMeta, error) {
 	type cfgNode struct {
 		Val    interface{}
 		Prefix string
-		Path   []string
+		Path   string
 	}
 
-	cfgStack := []cfgNode{{cfgRoot, "", nil}}
+	cfgStack := []cfgNode{{cfgRoot, "", ""}}
 	metas := make([]structMeta, 0)
 
 	for i := 0; i < len(cfgStack); i++ {
@@ -347,7 +347,7 @@ func readStructMetadata(cfgRoot interface{}) ([]structMeta, error) {
 					cfgStack = append(cfgStack, cfgNode{
 						Val:    fld.Addr().Interface(),
 						Prefix: sPrefix + prefix,
-						Path:   append(cfgStack[i].Path, fType.Name),
+						Path:   fmt.Sprintf("%s%s.", cfgStack[i].Path, fType.Name),
 					})
 					continue
 				}

--- a/cleanenv.go
+++ b/cleanenv.go
@@ -428,11 +428,13 @@ func readEnvVars(cfg interface{}, update bool) error {
 			}
 		}
 
+		var envName string
+		if len(meta.envList) > 0 {
+			envName = meta.envList[0]
+		}
+
 		if rawValue == nil && meta.required && meta.isFieldValueZero() {
-			return fmt.Errorf(
-				"field %q is required but the value is not provided",
-				meta.fieldName,
-			)
+			return newRequireError(meta.fieldName, envName)
 		}
 
 		if rawValue == nil && meta.isFieldValueZero() {
@@ -443,13 +445,8 @@ func readEnvVars(cfg interface{}, update bool) error {
 			continue
 		}
 
-		var envName string
-		if len(meta.envList) > 0 {
-			envName = meta.envList[0]
-		}
-
 		if err := parseValue(meta.fieldValue, *rawValue, meta.separator, meta.layout); err != nil {
-			return fmt.Errorf("parsing field %v env %v: %v", meta.fieldName, envName, err)
+			return newParsingError(meta.fieldName, envName, err)
 		}
 	}
 

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -333,6 +333,9 @@ func TestReadEnvErrors(t *testing.T) {
 			Host string        `env:"HOST" env-required:"true"`
 			TTL  time.Duration `env:"TTL"`
 		} `env-prefix:"TEST_ERRORS_DATABASE_"`
+		ThirdStruct struct {
+			Host string `env:"HOST"`
+		} `env-prefix:"TEST_ERRORS_THIRD_"`
 	}
 
 	tests := []struct {
@@ -348,7 +351,7 @@ func TestReadEnvErrors(t *testing.T) {
 			cfg:     &testEnvErrors{},
 			errorAs: RequireError{},
 			errorWant: RequireError{
-				FieldPath: []string{"Database"},
+				FieldPath: "Database.",
 				FieldName: "Host",
 				EnvName:   "TEST_ERRORS_DATABASE_HOST",
 			},
@@ -364,6 +367,7 @@ func TestReadEnvErrors(t *testing.T) {
 			errorWant: ParsingError{
 				Err:       fmt.Errorf("time: invalid duration \"bad-value\""),
 				FieldName: "TTL",
+				FieldPath: "Database.",
 				EnvName:   "TEST_ERRORS_DATABASE_TTL",
 			},
 		},

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -348,6 +348,7 @@ func TestReadEnvErrors(t *testing.T) {
 			cfg:     &testEnvErrors{},
 			errorAs: RequireError{},
 			errorWant: RequireError{
+				FieldPath: []string{"Database"},
 				FieldName: "Host",
 				EnvName:   "TEST_ERRORS_DATABASE_HOST",
 			},

--- a/errors.go
+++ b/errors.go
@@ -2,16 +2,15 @@ package cleanenv
 
 import (
 	"fmt"
-	"strings"
 )
 
 type RequireError struct {
 	FieldName string
-	FieldPath []string
+	FieldPath string
 	EnvName   string
 }
 
-func newRequireError(fieldName string, fieldPath []string, envName string) RequireError {
+func newRequireError(fieldName string, fieldPath string, envName string) RequireError {
 	return RequireError{
 		FieldName: fieldName,
 		FieldPath: fieldPath,
@@ -22,18 +21,18 @@ func newRequireError(fieldName string, fieldPath []string, envName string) Requi
 func (r RequireError) Error() string {
 	return fmt.Sprintf(
 		"field %q is required but the value is not provided",
-		strings.Join(append(r.FieldPath, r.FieldName), "."),
+		r.FieldPath+r.FieldName,
 	)
 }
 
 type ParsingError struct {
 	Err       error
 	FieldName string
-	FieldPath []string
+	FieldPath string
 	EnvName   string
 }
 
-func newParsingError(fieldName string, fieldPath []string, envName string, err error) ParsingError {
+func newParsingError(fieldName string, fieldPath string, envName string, err error) ParsingError {
 	return ParsingError{
 		FieldName: fieldName,
 		FieldPath: fieldPath,
@@ -44,8 +43,8 @@ func newParsingError(fieldName string, fieldPath []string, envName string, err e
 
 func (p ParsingError) Error() string {
 	return fmt.Sprintf(
-		"parsing field %v env %v: %v",
-		strings.Join(append(p.FieldPath, p.FieldName), "."),
+		"parsing field %q env %q: %v",
+		p.FieldPath+p.FieldName,
 		p.EnvName,
 		p.Err,
 	)

--- a/errors.go
+++ b/errors.go
@@ -2,16 +2,19 @@ package cleanenv
 
 import (
 	"fmt"
+	"strings"
 )
 
 type RequireError struct {
 	FieldName string
+	FieldPath []string
 	EnvName   string
 }
 
-func newRequireError(fieldName string, envName string) RequireError {
+func newRequireError(fieldName string, fieldPath []string, envName string) RequireError {
 	return RequireError{
 		FieldName: fieldName,
+		FieldPath: fieldPath,
 		EnvName:   envName,
 	}
 }
@@ -19,26 +22,33 @@ func newRequireError(fieldName string, envName string) RequireError {
 func (r RequireError) Error() string {
 	return fmt.Sprintf(
 		"field %q is required but the value is not provided",
-		r.FieldName,
+		strings.Join(append(r.FieldPath, r.FieldName), "."),
 	)
 }
 
 type ParsingError struct {
 	Err       error
 	FieldName string
+	FieldPath []string
 	EnvName   string
 }
 
-func newParsingError(fieldName string, envName string, err error) ParsingError {
+func newParsingError(fieldName string, fieldPath []string, envName string, err error) ParsingError {
 	return ParsingError{
 		FieldName: fieldName,
+		FieldPath: fieldPath,
 		EnvName:   envName,
 		Err:       err,
 	}
 }
 
 func (p ParsingError) Error() string {
-	return fmt.Sprintf("parsing field %v env %v: %v", p.FieldName, p.EnvName, p.Err)
+	return fmt.Sprintf(
+		"parsing field %v env %v: %v",
+		strings.Join(append(p.FieldPath, p.FieldName), "."),
+		p.EnvName,
+		p.Err,
+	)
 }
 
 func (p ParsingError) Unwrap() error {

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,46 @@
+package cleanenv
+
+import (
+	"fmt"
+)
+
+type RequireError struct {
+	FieldName string
+	EnvName   string
+}
+
+func newRequireError(fieldName string, envName string) RequireError {
+	return RequireError{
+		FieldName: fieldName,
+		EnvName:   envName,
+	}
+}
+
+func (r RequireError) Error() string {
+	return fmt.Sprintf(
+		"field %q is required but the value is not provided",
+		r.FieldName,
+	)
+}
+
+type ParsingError struct {
+	Err       error
+	FieldName string
+	EnvName   string
+}
+
+func newParsingError(fieldName string, envName string, err error) ParsingError {
+	return ParsingError{
+		FieldName: fieldName,
+		EnvName:   envName,
+		Err:       err,
+	}
+}
+
+func (p ParsingError) Error() string {
+	return fmt.Sprintf("parsing field %v env %v: %v", p.FieldName, p.EnvName, p.Err)
+}
+
+func (p ParsingError) Unwrap() error {
+	return p.Err
+}


### PR DESCRIPTION
With several nested structures with identical fields, there is no way to understand which error occurred.

This MP, without changing backward compatibility, adds a structure from which you can find out the field name.

If the community wishes, you can include the name in the error message.