### PR TITLE
Changed ConfigRemote to ConfigServer in 4th example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ type ConfigServer struct {
     Host     string `env:"HOST" env-description:"server host"`
 }
 
-var cfg ConfigRemote
+var cfg ConfigServer
 
 help, err := cleanenv.GetDescription(&cfg, nil)
 if err != nil {


### PR DESCRIPTION
```
import "github.com/ilyakaznacheev/cleanenv"

type ConfigServer struct {
    Port     string `env:"PORT" env-description:"server port"`
    Host     string `env:"HOST" env-description:"server host"`
}

var cfg ConfigRemote

help, err := cleanenv.GetDescription(&cfg, nil)
if err != nil {
    ...
}
```

`var cfg ConfigRemote`

must be:

`var cfg ConfigServer`