### PR TITLE
fix: add support for nested pointer structs

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -335,8 +335,16 @@ func readStructMetadata(cfgRoot interface{}) ([]structMeta, error) {
 				separator string
 			)
 
+			// read struct field info
+			fld := s.Field(idx)
+
+			// unwrap struct pointer
+			if fld.Kind() == reflect.Ptr {
+				fld = fld.Elem()
+			}
+
 			// process nested structure (except of supported ones)
-			if fld := s.Field(idx); fld.Kind() == reflect.Struct {
+			if fld.Kind() == reflect.Struct {
 				//skip unexported
 				if !fld.CanInterface() {
 					continue


### PR DESCRIPTION
Currently we have troubles with fields sets up as struct pointers:

```
type Config struct {
  Connection *PointerNestedStruct `yaml:"connection"`
}

type PointerNestedStruct struct {
  Timeout time.Duration `yaml:"timeout" env-default:"10s"`
}
```

After this changes default values will works fine.
