### PR TITLE
fix: support wrapper types in ReadEnv

### DIFF
--- a/cleanenv.go
+++ b/cleanenv.go
@@ -341,8 +341,12 @@ func readStructMetadata(cfgRoot interface{}) ([]structMeta, error) {
 				if !fld.CanInterface() {
 					continue
 				}
-				// add structure to parsing stack
-				if _, found := validStructs[fld.Type()]; !found {
+
+				// support wrapper types
+				_, implementsSetter := fld.Addr().Interface().(Setter)
+
+				// add structure to parsing stack if it's not valid
+				if _, found := validStructs[fld.Type()]; !found && !implementsSetter {
 					prefix, _ := fType.Tag.Lookup(TagEnvPrefix)
 					cfgStack = append(cfgStack, cfgNode{
 						Val:    fld.Addr().Interface(),

--- a/cleanenv_test.go
+++ b/cleanenv_test.go
@@ -1379,6 +1379,35 @@ func TestTimeLocation(t *testing.T) {
 	}
 }
 
+type StructSetter struct {
+	Value string
+}
+
+func (v *StructSetter) SetValue(s string) error {
+	v.Value = s
+	return nil
+}
+func TestStructSetter(t *testing.T) {
+	want := StructSetter{
+		Value: "bar",
+	}
+
+	var cfg struct {
+		Foo StructSetter `env:"FOO"`
+	}
+
+	os.Setenv("FOO", "bar")
+	defer os.Clearenv()
+
+	if err := ReadEnv(&cfg); err != nil {
+		t.Fatal("cannot read env:", err)
+	}
+
+	if !reflect.DeepEqual(cfg.Foo, want) {
+		t.Errorf("wrong data: got %v, want %v", cfg.Foo, want)
+	}
+}
+
 func TestSkipUnexportedField(t *testing.T) {
 	conf := struct {
 		Database struct {


### PR DESCRIPTION
If the user do not own the custom type they have to implement Setter on
a wrapper type to be able to use it with ReadEnv.

Fixes #106
